### PR TITLE
Custom data parsing + screen events

### DIFF
--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -9,6 +9,7 @@ import com.apptentive.android.sdk.ApptentiveLog;
 import com.apptentive.android.sdk.ApptentiveNotifications;
 import com.apptentive.android.sdk.conversation.Conversation;
 import com.apptentive.android.sdk.model.CommerceExtendedData;
+import com.apptentive.android.sdk.model.ExtendedData;
 import com.apptentive.android.sdk.notifications.ApptentiveNotification;
 import com.apptentive.android.sdk.notifications.ApptentiveNotificationCenter;
 import com.apptentive.android.sdk.notifications.ApptentiveNotificationObserver;
@@ -22,7 +23,6 @@ import com.mparticle.identity.MParticleUser;
 import org.json.JSONException;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -176,12 +176,7 @@ public class ApptentiveKit extends KitIntegration implements
 
 	@Override
 	public List<ReportingMessage> logEvent(MPEvent event) {
-		Map<String, String> customData = event.getInfo();
-		if (customData != null) {
-			Apptentive.engage(getContext(), event.getEventName(), parseCustomData(customData));
-		} else {
-			Apptentive.engage(getContext(), event.getEventName());
-		}
+		engage(getContext(), event.getEventName(), event.getInfo());
 		List<ReportingMessage> messageList = new LinkedList<ReportingMessage>();
 		messageList.add(ReportingMessage.fromEvent(this, event));
 		return messageList;
@@ -254,10 +249,9 @@ public class ApptentiveKit extends KitIntegration implements
 
 
 				if (apptentiveCommerceData != null) {
-					Map<String, String> customData = event.getCustomAttributes();
-					Apptentive.engage(getContext(),
+					engage(getContext(),
 							String.format("eCommerce - %s", event.getProductAction()),
-							customData == null ? null : parseCustomData(customData),
+							event.getCustomAttributes(),
 							apptentiveCommerceData);
 					List<ReportingMessage> messages = new LinkedList<ReportingMessage>();
 					messages.add(ReportingMessage.fromEvent(this, event));
@@ -295,6 +289,14 @@ public class ApptentiveKit extends KitIntegration implements
 	//endregion
 
 	//region Helpers
+
+	private void engage(Context context, String event, Map<String, String> customData) {
+		engage(context, event, customData, (ExtendedData[]) null);
+	}
+
+	private void engage(Context context, String event, Map<String, String> customData, ExtendedData... extendedData) {
+		Apptentive.engage(context, event, parseCustomData(customData), extendedData);
+	}
 
 	/* Apptentive SDK does not provide a function which accepts Object as custom data so we need to cast */
 	private void addCustomPersonData(String key, Object value) {

--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -170,9 +170,9 @@ public class ApptentiveKit extends KitIntegration implements
 
 	@Override
 	public List<ReportingMessage> logEvent(MPEvent event) {
-		Map<String, String> customData = event.getInfo();
+		Map<String, Object> customData = CustomDataParser.parse(event.getInfo());
 		if (customData != null) {
-			Apptentive.engage(getContext(), event.getEventName(), Collections.<String, Object>unmodifiableMap(customData));
+			Apptentive.engage(getContext(), event.getEventName(), customData);
 		} else {
 			Apptentive.engage(getContext(), event.getEventName());
 		}

--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -184,6 +184,7 @@ public class ApptentiveKit extends KitIntegration implements
 
 	@Override
 	public List<ReportingMessage> logScreen(String screenName, Map<String, String> eventAttributes) {
+		engage(getContext(), screenName, eventAttributes);
 		return null;
 	}
 

--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -253,7 +253,8 @@ public class ApptentiveKit extends KitIntegration implements
 					engage(getContext(),
 							String.format("eCommerce - %s", event.getProductAction()),
 							event.getCustomAttributes(),
-							apptentiveCommerceData);
+							apptentiveCommerceData
+					);
 					List<ReportingMessage> messages = new LinkedList<ReportingMessage>();
 					messages.add(ReportingMessage.fromEvent(this, event));
 					return messages;

--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -39,6 +39,9 @@ public class ApptentiveKit extends KitIntegration implements
 	private static final String APPTENTIVE_APP_KEY = "apptentiveAppKey";
 	private static final String Apptentive_APP_SIGNATURE = "apptentiveAppSignature";
 
+	private String lastKnownFirstName;
+	private String lastKnownLastName;
+
 	@Override
 	public String getName() {
 		return "Apptentive";
@@ -88,22 +91,19 @@ public class ApptentiveKit extends KitIntegration implements
 
 	@Override
 	public void setUserAttribute(String attributeKey, String attributeValue) {
-		String firstName = "";
-		String lastName = "";
-
 		if (attributeKey.equalsIgnoreCase(MParticle.UserAttributes.FIRSTNAME)) {
-			firstName = attributeValue;
+			lastKnownFirstName = attributeValue;
 		} else if (attributeKey.equalsIgnoreCase(MParticle.UserAttributes.LASTNAME)) {
-			lastName = attributeValue;
+			lastKnownLastName = attributeValue;
 		} else {
 			addCustomPersonData(attributeKey, parseValue(attributeValue));
 		}
 
 		String fullName;
-		if (!KitUtils.isEmpty(firstName) && !KitUtils.isEmpty(lastName)) {
-			fullName = firstName + " " + lastName;
+		if (!KitUtils.isEmpty(lastKnownFirstName) && !KitUtils.isEmpty(lastKnownLastName)) {
+			fullName = lastKnownFirstName + " " + lastKnownLastName;
 		} else {
-			fullName = firstName + lastName;
+			fullName = lastKnownFirstName + lastKnownLastName;
 		}
 		Apptentive.setPersonName(fullName.trim());
 	}

--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -28,6 +28,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static com.mparticle.kits.CustomDataParser.parseCustomData;
+import static com.mparticle.kits.CustomDataParser.parseValue;
+
 public class ApptentiveKit extends KitIntegration implements
 		KitIntegration.EventListener,
 		KitIntegration.CommerceListener,
@@ -125,7 +128,7 @@ public class ApptentiveKit extends KitIntegration implements
 			} else if (entry.getKey().equalsIgnoreCase(MParticle.UserAttributes.LASTNAME)) {
 				lastName = entry.getValue();
 			} else {
-				Apptentive.addCustomPersonData(entry.getKey(), entry.getValue());
+				Apptentive.addCustomPersonData(entry.getKey(), parseValue(entry.getValue());
 			}
 		}
 		String fullName;
@@ -170,9 +173,9 @@ public class ApptentiveKit extends KitIntegration implements
 
 	@Override
 	public List<ReportingMessage> logEvent(MPEvent event) {
-		Map<String, Object> customData = CustomDataParser.parse(event.getInfo());
+		Map<String, String> customData = event.getInfo();
 		if (customData != null) {
-			Apptentive.engage(getContext(), event.getEventName(), customData);
+			Apptentive.engage(getContext(), event.getEventName(), parseCustomData(customData));
 		} else {
 			Apptentive.engage(getContext(), event.getEventName());
 		}

--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -97,13 +97,16 @@ public class ApptentiveKit extends KitIntegration implements
 			lastKnownLastName = attributeValue;
 		} else {
 			addCustomPersonData(attributeKey, parseValue(attributeValue));
+			return;
 		}
 
-		String fullName;
-		if (!KitUtils.isEmpty(lastKnownFirstName) && !KitUtils.isEmpty(lastKnownLastName)) {
-			fullName = lastKnownFirstName + " " + lastKnownLastName;
-		} else {
-			fullName = lastKnownFirstName + lastKnownLastName;
+		String fullName = "";
+		if (!KitUtils.isEmpty(lastKnownFirstName)) {
+			fullName += lastKnownFirstName;
+		}
+		if (!KitUtils.isEmpty(lastKnownLastName)) {
+			if (fullName.length() > 0) { fullName += " "; }
+			fullName += lastKnownLastName;
 		}
 		Apptentive.setPersonName(fullName.trim());
 	}

--- a/src/main/java/com/mparticle/kits/ApptentiveKit.java
+++ b/src/main/java/com/mparticle/kits/ApptentiveKit.java
@@ -96,7 +96,7 @@ public class ApptentiveKit extends KitIntegration implements
 		} else if (attributeKey.equalsIgnoreCase(MParticle.UserAttributes.LASTNAME)) {
 			lastName = attributeValue;
 		} else {
-			Apptentive.addCustomPersonData(attributeKey, attributeValue);
+			addCustomPersonData(attributeKey, parseValue(attributeValue));
 		}
 
 		String fullName;
@@ -128,7 +128,7 @@ public class ApptentiveKit extends KitIntegration implements
 			} else if (entry.getKey().equalsIgnoreCase(MParticle.UserAttributes.LASTNAME)) {
 				lastName = entry.getValue();
 			} else {
-				Apptentive.addCustomPersonData(entry.getKey(), parseValue(entry.getValue());
+				addCustomPersonData(entry.getKey(), parseValue(entry.getValue()));
 			}
 		}
 		String fullName;
@@ -254,7 +254,7 @@ public class ApptentiveKit extends KitIntegration implements
 					Map<String, String> customData = event.getCustomAttributes();
 					Apptentive.engage(getContext(),
 							String.format("eCommerce - %s", event.getProductAction()),
-							customData == null ? null : Collections.<String, Object>unmodifiableMap(customData),
+							customData == null ? null : parseCustomData(customData),
 							apptentiveCommerceData);
 					List<ReportingMessage> messages = new LinkedList<ReportingMessage>();
 					messages.add(ReportingMessage.fromEvent(this, event));
@@ -286,6 +286,23 @@ public class ApptentiveKit extends KitIntegration implements
 
 				conversation.getPerson().setMParticleId(userId);
 			}
+		}
+	}
+
+	//endregion
+
+	//region Helpers
+
+	/* Apptentive SDK does not provide a function which accepts Object as custom data so we need to cast */
+	private void addCustomPersonData(String key, Object value) {
+		if (value instanceof String) {
+			Apptentive.addCustomPersonData(key, (String) value);
+		} else if (value instanceof Boolean) {
+			Apptentive.addCustomPersonData(key, (Boolean) value);
+		} else if (value instanceof Number) {
+			Apptentive.addCustomPersonData(key, (Number) value);
+		} else {
+			ApptentiveLog.e("Unexpected custom person data type: %s", value != null ? value.getClass() : null);
 		}
 	}
 

--- a/src/main/java/com/mparticle/kits/CustomDataParser.java
+++ b/src/main/java/com/mparticle/kits/CustomDataParser.java
@@ -1,0 +1,41 @@
+package com.mparticle.kits;
+
+import com.apptentive.android.sdk.ApptentiveLog;
+
+import java.util.HashMap;
+import java.util.Map;
+
+final class CustomDataParser {
+    public static Map<String, Object> parse(Map<String, String> map) {
+        Map<String, Object> res = new HashMap<>();
+        for (Map.Entry<String, String> e : map.entrySet()) {
+            res.put(e.getKey(), parseValue(e.getValue()));
+        }
+        return res;
+    }
+
+    private static Object parseValue(String value) {
+        try {
+            return value != null ? parseValueGuarded(value) : null;
+        } catch (Exception e) {
+            ApptentiveLog.e(e, "Unable to parse value: '%s'", value);
+            return value;
+        }
+    }
+
+    private static Object parseValueGuarded(String value) {
+        // check for boolean
+        if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+            return Boolean.parseBoolean(value);
+        }
+
+        // check for number
+        Number number = StringUtils.tryParseNumber(value);
+        if (number != null) {
+            return number;
+        }
+
+        // default to the original value
+        return value;
+    }
+}

--- a/src/main/java/com/mparticle/kits/CustomDataParser.java
+++ b/src/main/java/com/mparticle/kits/CustomDataParser.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 final class CustomDataParser {
-    public static Map<String, Object> parse(Map<String, String> map) {
+    public static Map<String, Object> parseCustomData(Map<String, String> map) {
         Map<String, Object> res = new HashMap<>();
         for (Map.Entry<String, String> e : map.entrySet()) {
             res.put(e.getKey(), parseValue(e.getValue()));
@@ -14,7 +14,7 @@ final class CustomDataParser {
         return res;
     }
 
-    private static Object parseValue(String value) {
+    public static Object parseValue(String value) {
         try {
             return value != null ? parseValueGuarded(value) : null;
         } catch (Exception e) {

--- a/src/main/java/com/mparticle/kits/StringUtils.java
+++ b/src/main/java/com/mparticle/kits/StringUtils.java
@@ -1,0 +1,31 @@
+package com.mparticle.kits;
+
+final class StringUtils {
+    public static Number tryParseNumber(String value) {
+        Long longValue = tryParseLong(value);
+        if (longValue != null) {
+            if (longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE) {
+                return longValue.intValue();
+            }
+            return longValue;
+        }
+
+        return tryParseDouble(value);
+    }
+
+    public static Long tryParseLong(String value) {
+        try {
+            return Long.valueOf(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public static Double tryParseDouble(String value) {
+        try {
+            return Double.valueOf(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/mparticle/kits/CustomDataParserTest.java
+++ b/src/test/java/com/mparticle/kits/CustomDataParserTest.java
@@ -1,0 +1,66 @@
+package com.mparticle.kits;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class CustomDataParserTest {
+    @Test
+    public void testParseData() {
+        Map<String, String> data = new HashMap<>();
+
+        // boolean
+        data.put("key-1", "true");
+        data.put("key-2", "True");
+        data.put("key-3", "false");
+        data.put("key-4", "False");
+
+        // integer
+        data.put("key-5", "12345");
+        data.put("key-6", "-12345");
+        data.put("key-7", Integer.toString(Integer.MIN_VALUE));
+        data.put("key-8", Integer.toString(Integer.MAX_VALUE));
+
+        // long
+        data.put("key-9", Long.toString(Long.MIN_VALUE));
+        data.put("key-10", Long.toString(Long.MAX_VALUE));
+
+        // double
+        data.put("key-11", "3.14");
+        data.put("key-12", "-3.14");
+
+        // string
+        data.put("key-13", "test");
+
+        Map<String, Object> expected = new HashMap<>();
+
+        // boolean
+        expected.put("key-1", Boolean.TRUE);
+        expected.put("key-2", Boolean.TRUE);
+        expected.put("key-3", Boolean.FALSE);
+        expected.put("key-4", Boolean.FALSE);
+
+        // integer
+        expected.put("key-5", 12345);
+        expected.put("key-6", -12345);
+        expected.put("key-7", Integer.MIN_VALUE);
+        expected.put("key-8", Integer.MAX_VALUE);
+
+        // long
+        expected.put("key-9", Long.MIN_VALUE);
+        expected.put("key-10", Long.MAX_VALUE);
+
+        // double
+        expected.put("key-11", 3.14);
+        expected.put("key-12", -3.14);
+
+        // string
+        expected.put("key-13", "test");
+
+        Map<String, Object> actual = CustomDataParser.parse(data);
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/com/mparticle/kits/CustomDataParserTest.java
+++ b/src/test/java/com/mparticle/kits/CustomDataParserTest.java
@@ -60,7 +60,7 @@ public class CustomDataParserTest {
         // string
         expected.put("key-13", "test");
 
-        Map<String, Object> actual = CustomDataParser.parse(data);
+        Map<String, Object> actual = CustomDataParser.parseCustomData(data);
         assertEquals(expected, actual);
     }
 }

--- a/src/test/java/com/mparticle/kits/StringUtilsTest.java
+++ b/src/test/java/com/mparticle/kits/StringUtilsTest.java
@@ -1,0 +1,17 @@
+package com.mparticle.kits;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class StringUtilsTest {
+    @Test
+    public void testParseNumber() {
+        assertEquals(Integer.valueOf(12345), (Integer) StringUtils.tryParseNumber("12345"));
+        assertEquals(Long.valueOf(21474836479L), (Long) StringUtils.tryParseNumber("21474836479"));
+        assertEquals(Long.valueOf(-21474836489L), (Long) StringUtils.tryParseNumber("-21474836489"));
+        assertEquals(Double.valueOf(12345.0), (Double) StringUtils.tryParseNumber("12345.0"));
+        assertNull(StringUtils.tryParseNumber("test"));
+    }
+}


### PR DESCRIPTION
mParticle passes user attribute data as `Map<String, String>` but the platform needs to work with numeric, string, and boolean types. An easy workaround is to attempt to parse string values into valid boolean and numbers or fall back to string values if not applicable.